### PR TITLE
Fix temp folder issue on Ubuntu.

### DIFF
--- a/commands/oarsman.go
+++ b/commands/oarsman.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/viper"
 	"os"
 	"os/user"
+    "path/filepath"
 )
 
 var CfgFile string
@@ -62,7 +63,7 @@ func InitializeConfig() {
 	workoutFolder := workingFolder + string(os.PathSeparator) + "workouts"
 	SetupFolder(workoutFolder, "WorkoutFolder", "Workout folder:")
 
-	tempFolder := os.TempDir() + "com.olympum.Oarsman"
+	tempFolder := filepath.Join(os.TempDir(), "com.olympum.Oarsman")
 	SetupFolder(tempFolder, "TempFolder", "Temp folder:")
 }
 

--- a/s4/s4.go
+++ b/s4/s4.go
@@ -86,10 +86,13 @@ type S4 struct {
 }
 
 func findUsbSerialModem() string {
-	contents, _ := ioutil.ReadDir("/dev")
+    //contents, _ := ioutil.ReadDir("/dev")
+    contents, _ := ioutil.ReadDir("/dev")
 
 	for _, f := range contents {
-		if strings.Contains(f.Name(), "cu.usbmodem") {
+		//if strings.Contains(f.Name(), "u.usbmodem") {
+			//return "/dev/" + f.Name()
+		if strings.Contains(f.Name(), "ttyACM0") {
 			return "/dev/" + f.Name()
 		}
 	}


### PR DESCRIPTION
Fixes #7 by using [filepath.Join()](https://golang.org/pkg/path/filepath/#Join).
The other dirs didn't have the same issue, so I didn't change their code. It may be safer to use `filepath.Join()` than `+ string(os.PathSeparator) +`

I cannot test on OSX or Windows.